### PR TITLE
Incorporate updates from LEAP feedback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react": "^18.3.1",
         "react-d3-gauge": "^0.0.1",
         "react-dom": "^18.3.1",
+        "react-loading": "^2.0.3",
         "react-redux": "^9.2.0",
         "react-router-dom": "^7.1.3",
         "react-simple-maps": "^3.0.0",
@@ -4735,6 +4736,16 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/react-loading": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/react-loading/-/react-loading-2.0.3.tgz",
+      "integrity": "sha512-Vdqy79zq+bpeWJqC+xjltUjuGApyoItPgL0vgVfcJHhqwU7bAMKzysfGW/ADu6i0z0JiOCRJjo+IkFNkRNbA3A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "prop-types": "^15.6.0",
+        "react": ">=0.14.0"
+      }
     },
     "node_modules/react-redux": {
       "version": "9.2.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react": "^18.3.1",
     "react-d3-gauge": "^0.0.1",
     "react-dom": "^18.3.1",
+    "react-loading": "^2.0.3",
     "react-redux": "^9.2.0",
     "react-router-dom": "^7.1.3",
     "react-simple-maps": "^3.0.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import {Fragment, useEffect, useState} from "react";
+import ReactLoading from "react-loading";
 import {BrowserRouter as Router, Link, Route, Routes} from "react-router-dom";
 import About from "./components/About";
 import Dashboard from "./components/Dashboard";
@@ -62,13 +63,11 @@ function App() {
 
     if (topographyLoading || dashboardStatsLoading || countyCountsLoading) {
         return (
-            <div className="dashboard">
-                <div className="wrapper">
-                    <header className="flex justify-between m-auto p-[1.5vh]">
-                        <img src="/images/logo_main.png" alt="Logo" className="logo"/>
-                    </header>
+            <Fragment>
+                <div className="flex h-screen items-center justify-center">
+                    <ReactLoading type="spin" color="black" height="10%" width="10%" />
                 </div>
-            </div>
+            </Fragment>
         )
     }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -65,7 +65,7 @@ function App() {
         return (
             <Fragment>
                 <div className="flex h-screen items-center justify-center">
-                    <ReactLoading type="spin" color="black" height="10%" width="10%" />
+                    <ReactLoading type="spin" color="#4292c6" height="5%" width="5%" />
                 </div>
             </Fragment>
         )

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,6 +25,7 @@ function App() {
                     <div style={{paddingTop: "1em"}}>
                         <Toggle
                             defaultChecked={showHouseholdAverages}
+                            icons={false}
                             onChange={() => setShowHouseholdAverages(!showHouseholdAverages)}
                         />
                     </div>

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -3,11 +3,14 @@ import _ from "lodash";
 import DashboardMap from "./DashboardMap.jsx";
 
 function createMap(dashboardStats, columnMapping) {
-    const dashboardStatsMap = new Map();
-    _.chain(_.map(columnMapping, (entry) => entry.column)).forEach((column) => {
-        dashboardStatsMap.set(column, dashboardStats[column]);
-    }).value();
-    return dashboardStatsMap;
+    if (dashboardStats) {
+        const dashboardStatsMap = new Map();
+        _.chain(_.map(columnMapping, (entry) => entry.column)).forEach((column) => {
+            dashboardStatsMap.set(column, dashboardStats[column]);
+        }).value();
+        return dashboardStatsMap;
+    }
+    return new Map();
 }
 
 function createStatCard(showHouseHoldAverages, columnMapping, column, values) {
@@ -86,10 +89,12 @@ export default function Dashboard({ showHouseholdAverages, dashboardStats, topog
             }
             <div className="map-container col-span-3 row-span-3">
                 <h2 className="stat-heading">Where We Serve in Virginia</h2>
-                <DashboardMap
-                    height={500}
-                    data={{ topography, countyCounts }}
-                />
+                {
+                    countyCounts && <DashboardMap
+                        height={500}
+                        data={{ topography, countyCounts }}
+                    />
+                }
             </div>
             {
                 Array.from(dashboardStatsMap.entries())

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1,22 +1,31 @@
-import Map from "./Map";
 import { Fragment } from "react";
 import _ from "lodash";
 import DashboardMap from "./DashboardMap.jsx";
 
-function createStatCard(showHouseHoldAverages, currencyColumns, column, values) {
+function createMap(dashboardStats, columnMapping) {
+    const dashboardStatsMap = new Map();
+    _.chain(_.map(columnMapping, (entry) => entry.column)).forEach((column) => {
+        dashboardStatsMap.set(column, dashboardStats[column]);
+    }).value();
+    return dashboardStatsMap;
+}
+
+function createStatCard(showHouseHoldAverages, columnMapping, column, values) {
     let aggregatedValue;
     if (!showHouseHoldAverages) {
         aggregatedValue = _.round(_.sum(values) / 1000) + 'K';
     } else {
         aggregatedValue = _.round(_.mean(values));
     }
-    if (_.includes(currencyColumns, column)) {
+    const isCurrencyType = _.chain(columnMapping).filter(entry => entry.type === 'currency').map((entry) => entry.column).includes(column).value();
+    if (isCurrencyType) {
         aggregatedValue = '$' + aggregatedValue;
     }
+    const dashboardDisplay = _.chain(columnMapping).filter(entry => entry.column === column).map((entry) => entry.dashboardDisplay).value();
     return (
         <Fragment key={column}>
             <div className="card stat-card">
-                <h2 className="stat-heading">{column}</h2>
+                <h2 className="stat-heading">{dashboardDisplay}</h2>
                 <span className="stat">{aggregatedValue}</span>
             </div>
         </Fragment>
@@ -25,22 +34,46 @@ function createStatCard(showHouseHoldAverages, currencyColumns, column, values) 
 }
 
 export default function Dashboard({ showHouseholdAverages, dashboardStats, topography, countyCounts }) {
-    const numericalColumns = [
-        'kWh Saved',
-        'CO₂ Tons',
-        'Annual Fuel Therms Saved'
+    const columnMapping = [
+        {
+            'column': 'kWh Saved',
+            'dashboardDisplay': 'kWh Saved',
+            'type': 'numerical',
+        },
+        {
+            'column': 'Annual Fuel Therms Saved',
+            'dashboardDisplay': 'Annual Fuel Therms Saved',
+            'type': 'numerical',
+        },
+        {
+            'column': 'Annual Fuel Dollars',
+            'dashboardDisplay': 'Total Annual Energy Savings',
+            'type': 'currency',
+        },
+        {
+            'column': 'Annual Electric Dollars',
+            'dashboardDisplay': 'Annual Electric Dollars',
+            'type': 'currency',
+        },
+        {
+            'column': 'CO₂ Tons',
+            'dashboardDisplay': 'CO₂ Tons',
+            'type': 'numerical',
+        },
+        {
+            'column': 'Total Savings',
+            'dashboardDisplay': 'Cumulative Savings',
+            'type': 'currency',
+        },
     ];
-    const currencyColumns = [
-        'Annual Fuel Dollars',
-        'Annual Electric Dollars',
-        'Total Savings'
-    ];
-    let firstRowColumns = _.concat(numericalColumns, [currencyColumns[0]])
-    let secondRowColumns = _.range(1, currencyColumns.length).map((idx) => currencyColumns[idx]);
+
+    const dashboardStatsMap = createMap(dashboardStats, columnMapping);
+    const firstRowColumns = _.chain(columnMapping).map((entry) => entry.column).take(4).value();
+    const secondRowColumns = _.chain(columnMapping).map((entry) => entry.column).splice(4).value();
     return (
         <div className="grid grid-cols-4 gap-4">
             {
-                Object.entries(dashboardStats)
+                Array.from(dashboardStatsMap.entries())
                     .filter((entry) => {
                         let column = entry[0];
                         return _.includes(firstRowColumns, column);
@@ -48,7 +81,7 @@ export default function Dashboard({ showHouseholdAverages, dashboardStats, topog
                     .map((entry) => {
                         let column = entry[0];
                         let values = entry[1];
-                        return createStatCard(showHouseholdAverages, currencyColumns, column, values);
+                        return createStatCard(showHouseholdAverages, columnMapping, column, values);
                     })
             }
             <div className="map-container col-span-3 row-span-3">
@@ -59,7 +92,7 @@ export default function Dashboard({ showHouseholdAverages, dashboardStats, topog
                 />
             </div>
             {
-                Object.entries(dashboardStats)
+                Array.from(dashboardStatsMap.entries())
                     .filter((entry) => {
                         let column = entry[0];
                         return _.includes(secondRowColumns, column);
@@ -67,7 +100,7 @@ export default function Dashboard({ showHouseholdAverages, dashboardStats, topog
                     .map((entry) => {
                         let column = entry[0];
                         let values = entry[1];
-                        return createStatCard(showHouseholdAverages, currencyColumns, column, values);
+                        return createStatCard(showHouseholdAverages, columnMapping, column, values);
                     })
             }
         </div >

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -26,7 +26,7 @@ function createStatCard(showHouseHoldAverages, currencyColumns, column, values) 
 export default function Dashboard({ showHouseholdAverages, dashboardStats, topography, countyCounts }) {
     const numericalColumns = [
         'kWh Saved',
-        'CO 2 Tons',
+        'CO₂ Tons',
         'Annual Fuel Therms Saved'
     ];
     const currencyColumns = [

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -5,8 +5,7 @@ import _ from "lodash";
 
 function createStatCard(showHouseHoldAverages, currencyColumns, column, values) {
     let aggregatedValue;
-    // Total Savings is calculated by summing up all households regardless of toggle state
-    if (column === "Total Savings" || !showHouseHoldAverages) {
+    if (!showHouseHoldAverages) {
         aggregatedValue = _.round(_.sum(values) / 1000) + 'K';
     } else {
         aggregatedValue = _.round(_.mean(values));

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1,6 +1,7 @@
 import Map from "./Map";
 import { Fragment } from "react";
 import _ from "lodash";
+import DashboardMap from "./DashboardMap.jsx";
 
 function createStatCard(showHouseHoldAverages, currencyColumns, column, values) {
     let aggregatedValue;
@@ -52,7 +53,7 @@ export default function Dashboard({ showHouseholdAverages, dashboardStats, topog
             }
             <div className="map-container col-span-3 row-span-3">
                 <h2 className="stat-heading">Where We Serve in Virginia</h2>
-                <Map
+                <DashboardMap
                     height={500}
                     data={{ topography, countyCounts }}
                 />

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1,5 +1,4 @@
 import Map from "./Map";
-import Gauge from "./Gauge";
 import { Fragment } from "react";
 import _ from "lodash";
 
@@ -24,18 +23,6 @@ function createStatCard(showHouseHoldAverages, currencyColumns, column, values) 
 
 }
 
-function createGaugeCard(column, values) {
-    let aggregatedValue = _.mean(values);
-    return (
-        <Fragment key={column}>
-            <div className="gauge-container">
-                <h2 className="stat-heading">{column}</h2>
-                <Gauge value={parseFloat(aggregatedValue.toFixed(2))}/>
-            </div>
-        </Fragment>
-    )
-}
-
 export default function Dashboard({ showHouseholdAverages, dashboardStats, topography, countyCounts }) {
     const numericalColumns = [
         'kWh Saved',
@@ -48,8 +35,7 @@ export default function Dashboard({ showHouseholdAverages, dashboardStats, topog
         'Total Savings'
     ];
     let firstRowColumns = _.concat(numericalColumns, [currencyColumns[0]])
-    const gaugeColumn = 'HVAC Duct Efficiency';
-    let thirdRowColumns = _.range(1, currencyColumns.length).map((idx) => currencyColumns[idx]);
+    let secondRowColumns = _.range(1, currencyColumns.length).map((idx) => currencyColumns[idx]);
     return (
         <div className="grid grid-cols-4 gap-4">
             {
@@ -75,16 +61,13 @@ export default function Dashboard({ showHouseholdAverages, dashboardStats, topog
                 Object.entries(dashboardStats)
                     .filter((entry) => {
                         let column = entry[0];
-                        return _.includes(thirdRowColumns, column);
+                        return _.includes(secondRowColumns, column);
                     })
                     .map((entry) => {
                         let column = entry[0];
                         let values = entry[1];
                         return createStatCard(showHouseholdAverages, currencyColumns, column, values);
                     })
-            }
-            {
-                createGaugeCard(gaugeColumn, dashboardStats[gaugeColumn])
             }
         </div >
     );

--- a/src/components/DashboardMap.jsx
+++ b/src/components/DashboardMap.jsx
@@ -4,7 +4,7 @@ import { ComposableMap, Geographies, Geography } from "react-simple-maps";
 import Legend from "./Legend";
 import useChartDimensions from "../hooks/useChartDimensions";
 
-const Map = ({ height, data }) => {
+const DashboardMap = ({ height, data }) => {
   const { topography, countyCounts } = data;
 
   const [ref, dms] = useChartDimensions({});
@@ -95,4 +95,4 @@ const Map = ({ height, data }) => {
   );
 };
 
-export default Map;
+export default DashboardMap;

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -88,7 +88,7 @@ const Map = ({ height, data }) => {
         >
           {tooltipData.name}
           <br />
-          People Served: {tooltipData.county}
+          Households Served: {tooltipData.county}
         </div>
       )}
     </div>

--- a/src/store/countyCountsSlice.js
+++ b/src/store/countyCountsSlice.js
@@ -47,19 +47,17 @@ export const fetchIntakeDataFromApi = createAsyncThunk(
 
 const countyCountsSlice = createSlice({
     name: 'countyCounts',
-    initialState: {},
-    reducers: {
-        setCountyCounts: (state, action) => {
-            return action.payload;
-        }
+    initialState: {
+        "countyCountsLoading": true,
+        "countyCountsData": {}
     },
+    reducers: {},
     extraReducers: (builder) => {
         builder.addCase(fetchIntakeDataFromApi.fulfilled, (state, action) => {
-            const counties = _.map(action.payload, (item) => item.column_values[0].text);
-            return  _.countBy(counties);
+            const counties = _.map(action.payload, (item) => item?.column_values[0].text);
+            return {"countyCountsLoading": false, "countyCountsData": _.countBy(counties)};
         });
     }
 });
 
-export const { setCountyCounts } = countyCountsSlice.actions;
 export default countyCountsSlice.reducer;

--- a/src/store/dashboardStatsSlice.js
+++ b/src/store/dashboardStatsSlice.js
@@ -10,7 +10,7 @@ export const fetchProjectSavingsDataFromApi = createAsyncThunk(
                 "    items_page(limit: 500) {\n" +
                 "      items {\n" +
                 "        column_values(\n" +
-                "          ids: [\"numbers3__1\", \"numbers4__1\", \"numbers_2__1\", \"numbers_3__1\", \"numbers_4__1\", \"numbers_5__1\", \"numbers05__1\"]\n" +
+                "          ids: [\"numbers3__1\", \"numbers4__1\", \"numbers_2__1\", \"numbers_3__1\", \"numbers_4__1\", \"numbers_5__1\"]\n" +
                 "        ) {\n" +
                 "          column {\n" +
                 "            title\n" +

--- a/src/store/dashboardStatsSlice.js
+++ b/src/store/dashboardStatsSlice.js
@@ -31,7 +31,10 @@ export const fetchProjectSavingsDataFromApi = createAsyncThunk(
 
 const dashboardStatsSlice = createSlice({
     name: 'dashboardStats',
-    initialState: {},
+    initialState: {
+        "dashboardStatsLoading": true,
+        "dashboardStatsData": {}
+    },
     reducers: {},
     extraReducers: (builder) => {
         builder.addCase(fetchProjectSavingsDataFromApi.fulfilled, (state, action) => {
@@ -51,7 +54,10 @@ const dashboardStatsSlice = createSlice({
                     }
                 });
             });
-            return newData;
+            return {
+                "dashboardStatsLoading": false,
+                "dashboardStatsData": newData
+            }
         });
     }
 });

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,12 +1,12 @@
 import topography from './topographySlice';
-import countryCounts from './countyCountsSlice';
+import countyCounts from './countyCountsSlice';
 import dashboardStats from './dashboardStatsSlice';
 import { configureStore } from '@reduxjs/toolkit';
 
 const store = configureStore({
     reducer: {
         topography,
-        countryCounts,
+        countyCounts,
         dashboardStats
     }
 });

--- a/src/store/topographySlice.js
+++ b/src/store/topographySlice.js
@@ -1,6 +1,5 @@
 import {createAsyncThunk, createSlice} from '@reduxjs/toolkit';
 import * as d3 from "d3";
-import {setCountyCounts} from "./countyCountsSlice.js";
 
 export const fetchGeoJsonDataLocally = createAsyncThunk(
     'fetchGeoJsonDataLocally', async () => {
@@ -14,20 +13,14 @@ export const fetchGeoJsonDataLocally = createAsyncThunk(
 
 const topographySlice = createSlice({
     name: 'topography',
-    initialState: null,
+    initialState: {
+        "topographyLoading": true,
+        "topographyData": null
+    },
     reducers: {},
     extraReducers: (builder) => {
         builder.addCase(fetchGeoJsonDataLocally.fulfilled, (state, action) => {
-            return action.payload;
-        });
-
-        builder.addCase(setCountyCounts, (state, action) => {
-            const updatedGeoJson = state;
-            updatedGeoJson.features.forEach((feature) => {
-                const county = feature.properties.NAMELSAD.trim();
-                feature.properties.count = action.payload[county] || 0;
-            });
-            return updatedGeoJson;
+            return {"topographyLoading": false, "topographyData": action.payload};
         });
     }
 });


### PR DESCRIPTION
Here are the changes that have been implemented in this PR:
- [x] Remove the x and check mark on the toggle
- [x] Make the total savings show household averages
- [x] Add a loading component as a buffer to show data is loading
- [x] When hovering over a given city/county on the map, change "people served" to "households served"
- [x] Remove "HVAC Duct efficiency" as a metric
- [ ] Add a section for total solar energy saving statistics as a metric
- [x] Change section from "annual fuel dollars" to "total annual energy savings" and "total savings to cumulative savings"
- [x] Group kwh/therms cards closer together as well as the $ savings
- [ ] Make the dashboard responsive to different mobile screens